### PR TITLE
Add link to 2025

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ layout: home
 
 <hr>
 
-<h2> Announcement: The deadline has been extended thanks to additional funding. </h2>
+<h2>For 2025 edition, please go to <a href="https://dare-lisbon.github.io">DARE 2025, September 8-12, Lisbon, Portugal</a>!</h2>
 
 <hr>
 


### PR DESCRIPTION
I just accidentally pointed my student to the 2024 page, because DARE 2024 is much higher in Google search results than DARE 2025 (even if I search for "DARE 2025"!) Hopefully this can help others avoid the same mistake :-)